### PR TITLE
fix: Fix flip error state

### DIFF
--- a/src/utils/gl-utils.js
+++ b/src/utils/gl-utils.js
@@ -194,6 +194,7 @@ export const update2DTexture = (gl, texture, val) => {
   // Image may not be provided when updating texture params
   if (image) {
     if (flip) gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
+    else gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false)
     const s = native(space || GL.RGBA)
     gl.texImage2D(gl.TEXTURE_2D, 0, s, s, gl.UNSIGNED_BYTE, image)
     if (supportMipmap(image)) gl.generateMipmap(gl.TEXTURE_2D)
@@ -247,6 +248,7 @@ export const updateCubeTexture = (gl, texture, val) => {
   // Image may not be provided when updating texture params
   if (images) {
     if (flip) gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
+    else gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false)
     const faces = [
       gl.TEXTURE_CUBE_MAP_POSITIVE_X,
       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,


### PR DESCRIPTION
The flip of the opengl context state machine is not set correctly after being modified

For example, the first texture expects flip to be true, and the second texture expects flip to be false. Now the result will be flip to true.