### PR TITLE
fix: 移除耗时的操作，修复拼写错误等

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -85,7 +85,7 @@ declare namespace Beam {
   }
 
   interface TextureState {
-    image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
+    image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap
     /** @default false */
     flip?: boolean
     /** @default GLTypes.Repeat */

--- a/src/target.js
+++ b/src/target.js
@@ -20,7 +20,7 @@ export class OffscreenTarget {
     const { beam, state } = this
     if (width === state.width && height === state.height) return
 
-    glUtils.resetOffscren(beam.gl, this)
+    glUtils.resetOffscreen(beam.gl, this)
     state.width = width
     state.height = height
     this._init()
@@ -40,7 +40,6 @@ export class OffscreenTarget {
 
   _before() {
     const { gl } = this.beam
-    this._viewport = gl.getParameter(gl.VIEWPORT)
     this.state.depth
       ? glUtils.beforeDrawToDepth(this.beam.gl, this)
       : glUtils.beforeDrawToColor(this.beam.gl, this)
@@ -49,7 +48,6 @@ export class OffscreenTarget {
   _after() {
     const { gl } = this.beam
     gl.bindFramebuffer(gl.FRAMEBUFFER, null)
-    gl.viewport(...this._viewport)
   }
 
   use(drawCallback = () => {}) {

--- a/src/target.js
+++ b/src/target.js
@@ -1,13 +1,14 @@
 import * as glUtils from './utils/gl-utils.js'
 
 export class OffscreenTarget {
-  constructor(beam, width, height, depth = false) {
+  constructor(beam, width, height, depth = false, debug = false) {
     const { gl } = beam
     this.beam = beam
     this.state = {
       width: width !== undefined ? width : gl.canvas.width,
       height: height !== undefined ? height : gl.canvas.height,
       depth,
+      debug,
     }
     this._init()
   }

--- a/src/utils/gl-utils.js
+++ b/src/utils/gl-utils.js
@@ -331,10 +331,10 @@ const initColorOffscreen = (gl, state) => {
     rbo
   )
 
-  const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
-  if (gl.FRAMEBUFFER_COMPLETE !== e) {
-    console.error('Frame buffer object is incomplete: ' + e.toString())
-  }
+  // const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+  // if (gl.FRAMEBUFFER_COMPLETE !== e) {
+  //   console.error('Frame buffer object is incomplete: ' + e.toString())
+  // }
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null)
   gl.bindTexture(gl.TEXTURE_2D, null)
@@ -415,7 +415,7 @@ export const initOffscreen = (gl, state) => {
  * @param {WebGLRenderingContext} gl
  * @param {*} target
  */
-export const resetOffscren = (gl, target) => {
+export const resetOffscreen = (gl, target) => {
   gl.deleteFramebuffer(target.fbo)
   gl.deleteRenderbuffer(target.rbo)
   gl.deleteTexture(target.colorTexture)
@@ -467,8 +467,8 @@ export const draw = (
   Object.keys(shaderRefs.uniforms).forEach((key) => {
     const { type, location } = shaderRefs.uniforms[key]
     let val
-    const isTexure = type === SchemaTypes.tex2D || type === SchemaTypes.texCube
-    if (!isTexure) {
+    const isTexture = type === SchemaTypes.tex2D || type === SchemaTypes.texCube
+    if (!isTexture) {
       val = padDefault(schema, key, uniforms[key])
     }
 
@@ -513,7 +513,7 @@ export const draw = (
       },
     }
     // FIXME uniform keys padded by default are always re-uploaded.
-    if (val !== undefined || isTexure) uniformSetterMapping[type]()
+    if (val !== undefined || isTexture) uniformSetterMapping[type]()
   })
 
   const drawMode = schema.mode === GL.Triangles ? gl.TRIANGLES : gl.LINES

--- a/src/utils/gl-utils.js
+++ b/src/utils/gl-utils.js
@@ -297,7 +297,7 @@ const initColorOffscreen = (gl, state) => {
   const colorTexture = gl.createTexture()
   const depthTexture = null
 
-  const { width, height } = state
+  const { width, height, debug = false } = state
   gl.bindTexture(gl.TEXTURE_2D, colorTexture)
   gl.texImage2D(
     gl.TEXTURE_2D,
@@ -331,10 +331,12 @@ const initColorOffscreen = (gl, state) => {
     rbo
   )
 
-  // const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
-  // if (gl.FRAMEBUFFER_COMPLETE !== e) {
-  //   console.error('Frame buffer object is incomplete: ' + e.toString())
-  // }
+  if (debug) {
+    const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+    if (gl.FRAMEBUFFER_COMPLETE !== e) {
+      console.error('Frame buffer object is incomplete: ' + e.toString())
+    }
+  }
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null)
   gl.bindTexture(gl.TEXTURE_2D, null)
@@ -344,7 +346,7 @@ const initColorOffscreen = (gl, state) => {
 }
 
 const initDepthOffscreen = (gl, state) => {
-  const { width, height } = state
+  const { width, height, debug = false } = state
 
   const fbo = gl.createFramebuffer()
   const rbo = null
@@ -396,9 +398,11 @@ const initDepthOffscreen = (gl, state) => {
     0
   )
 
-  const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
-  if (e !== gl.FRAMEBUFFER_COMPLETE) {
-    console.error('framebuffer not complete', e.toString())
+  if (debug) {
+    const e = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+    if (e !== gl.FRAMEBUFFER_COMPLETE) {
+      console.error('framebuffer not complete', e.toString())
+    }
   }
 
   gl.bindTexture(gl.TEXTURE_2D, null)


### PR DESCRIPTION
gl.getParameter(gl.VIEWPORT) 有时耗时超过5 ms 不建议强制使用，建议手动管理
checkFramebufferStatus 检查耗时非常高，建议删除