### PR TITLE
docs: unify install command to pnpm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pnpm docs:dev                      # run the docs site (VitePress)
 ## Install
 
 ```bash
-npm i beam-gpu
+pnpm add beam-gpu
 ```
 
 ## License


### PR DESCRIPTION
The Develop section uses `pnpm` throughout, but the Install section still showed `npm i beam-gpu`. Since Beam is a pnpm workspace, this unifies the package-manager style by using `pnpm add beam-gpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)